### PR TITLE
[fixes#3] cleanup + performance

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,17 +1,16 @@
-var RSVP = require('rsvp')
+var Promise = require('rsvp').Promise;
 
-module.exports = function promiseMapSeries (array, iterator, thisArg) {
-  var results = new Array(array.length)
-  var index = 0
-  return array.reduce(function (promise, item) {
-      return promise.then(function () {
-          return iterator.call(thisArg, item, index, array)
-        })
-        .then(function (result) {
-          results[index++] = result
-        })
-    }, RSVP.resolve())
-    .then(function () {
-      return results
-    })
+module.exports = function sequence(array, iterator, thisArg) {
+  var length = array.length
+  var current = Promise.resolve()
+  var results = new Array(length)
+  var cb = arguments.length > 2 ? iterator.bind(thisArg) : iterator
+
+  for (var i = 0; i < length; ++i) {
+    current = results[i] = current.then(function(i) {
+      return cb(array[i], i, array)
+    }.bind(undefined, i))
+  }
+
+  return Promise.all(results)
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/joliss/promise-map-series"
   },
   "dependencies": {
-    "rsvp": "^3.0.6"
+    "rsvp": "^3.0.14"
   },
   "devDependencies": {
     "tape": "^2.5.0"


### PR DESCRIPTION
- only allocate n+2 promises, rather then 4n+2
- only rebind the iterated if needed
- only rebind the iterator once.
- upgrade RSVP
