### PR TITLE
benchmarks and variations

### DIFF
--- a/benchmarks/bench.js
+++ b/benchmarks/bench.js
@@ -1,0 +1,34 @@
+var Benchmark = require('benchmark');
+
+function log(message) {
+  if (typeof window !== 'undefined') {
+    var div = document.createElement('div');
+    div.textContent = message;
+    document.getElementById('output').appendChild(div);
+  } else  {
+    console.log(message);
+  }
+}
+
+module.exports = function(suites) {
+  var suite = new Benchmark.Suite();
+
+  log('testing');
+  suites.forEach(function(s) {
+    log('- ' + s.name);
+    suite.add(s.name, s.fn, { defer: true });
+  });
+
+  suite.on('cycle', function(event) {
+    log(String(event.target));
+  })
+  .on('complete', function() {
+    log('Fastest is ' + this.filter('fastest').pluck('name'));
+  });
+
+  setTimeout(function() {
+    suite.run({
+      'async': true
+    });
+  }, 1000);
+}

--- a/benchmarks/test.js
+++ b/benchmarks/test.js
@@ -1,0 +1,43 @@
+var current = require('../');
+var RSVP = require('rsvp');
+var assert = require('assert');
+var index = 0;
+var input = new Array(10);
+
+// populate input to prevent spare array which old merely skips over
+for (var i = 0; i < input.length; i++) {
+  input[i] = i;
+}
+
+function test(implementationPath) {
+  var implementation = require(implementationPath);
+
+  return function(deferred){
+    implementation(input, function(item) {
+      return new RSVP.Promise(function(resolve) {
+        setTimeout(function() {
+          resolve(item);
+        }, 10);
+      });
+    }).then(function(results) {
+      assert.deepEqual(results, input, implementationPath);
+      deferred.resolve();
+    }).catch(function(reason) {
+      console.error(reason);
+      console.error(reason.stack);
+    });
+  };
+}
+
+//test(require(variationPath))({
+//  resolve: function() {
+//    console.log('done');
+//  }
+//});
+
+require('./bench')([
+  { name: 'current'      , fn: test('../') },
+  { name: 'other'        , fn: test('./variations/index') },
+  { name: 'old'          , fn: test('./variations/old') },
+  { name: 'old-variation', fn: test('./variations/old-variation') }
+]);

--- a/benchmarks/variations/index.js
+++ b/benchmarks/variations/index.js
@@ -1,0 +1,18 @@
+var Promise = require('rsvp').Promise;
+
+module.exports = function sequence(array, iterator, thisArg) {
+  var length = array.length
+  var current = Promise.resolve()
+  var results = new Array(length)
+  var cb = arguments.length > 2 ? iterator.bind(thisArg) : iterator
+
+  for (var i = 0; i < length; ++i) {
+    current = results[i] = current.then(function(i) {
+      return cb(array[i], i, array)
+    }.bind(undefined, i))
+  }
+
+  return current.then(function() {
+    return Promise.all(results);
+  });
+}

--- a/benchmarks/variations/old-variation.js
+++ b/benchmarks/variations/old-variation.js
@@ -1,0 +1,19 @@
+var RSVP = require('rsvp');
+
+module.exports = function promiseMapSeries (array, iterator, thisArg) {
+  var results = new Array(array.length)
+  var index = 0
+  var cb = arguments.length > 2 ? iterator.bind(thisArg) : iterator
+
+  return array.reduce(function (promise, item) {
+      return promise.then(function () {
+          return cb(item, index, array)
+        })
+        .then(function (result) {
+          results[index++] = result
+        })
+    }, RSVP.resolve())
+    .then(function () {
+      return results
+    })
+}

--- a/benchmarks/variations/old.js
+++ b/benchmarks/variations/old.js
@@ -1,0 +1,17 @@
+var RSVP = require('rsvp');
+
+module.exports = function promiseMapSeries (array, iterator, thisArg) {
+  var results = new Array(array.length)
+  var index = 0
+  return array.reduce(function (promise, item) {
+      return promise.then(function () {
+          return iterator.call(thisArg, item, index, array)
+        })
+        .then(function (result) {
+          results[index++] = result
+        })
+    }, RSVP.resolve())
+    .then(function () {
+      return results
+    })
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "rsvp": "^3.0.14"
   },
   "devDependencies": {
+    "benchmark": "^1.0.0",
     "tape": "^2.5.0"
   },
   "scripts": {


### PR DESCRIPTION
they are all basically the same, my sequence changes were from a what appears now to be a very different scenario. I thought they would be transferrable.

As always benchmarks are basically lolcode, so another set of eyes is good.

please note, each of the 10 async steps are `setTimeout(fn, 0)` 

```
± % node ./benchmarks/test.js                                                                 !10222
testing
- current
- other
- old
- old-variation
current x 67.58 ops/sec ±1.56% (81 runs sampled)
other x 68.13 ops/sec ±0.95% (82 runs sampled)
old x 60.85 ops/sec ±5.11% (74 runs sampled)
old-variation x 55.04 ops/sec ±5.08% (67 runs sampled)
Fastest is other,current
```