### PR TITLE
Use any-promise instead of RSVP

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var Promise = require('rsvp').Promise;
+var Promise = require('any-promise');
 
 module.exports = function sequence(array, iterator, thisArg) {
   var length = array.length

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/joliss/promise-map-series"
   },
   "dependencies": {
-    "rsvp": "^3.0.14"
+    "any-promise": "^0.1.0"
   },
   "devDependencies": {
     "tape": "^2.5.0"


### PR DESCRIPTION
Use any-promise instead of RSVP, to resolve any installed ES6 compatible promise, and remove dependency of RSVP